### PR TITLE
Add styled WaniKani-like UI

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -2,6 +2,19 @@ from sqlalchemy.orm import Session
 from . import models, schemas
 import time
 
+# Summary stats
+def get_summary(db: Session):
+    now = int(time.time())
+    total_words = db.query(models.Word).count()
+    lessons_available = db.query(models.SRSItem).filter(models.SRSItem.level == 0).count()
+    reviews_due = db.query(models.SRSItem).filter(models.SRSItem.next_review <= now).count()
+    return {
+        "total_words": total_words,
+        "lessons_available": lessons_available,
+        "reviews_due": reviews_due,
+    }
+
+
 SRS_STEPS = [1, 2, 4, 8, 16]
 
 # Words

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,6 +19,11 @@ def get_db():
 def read_words(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
     return crud.get_words(db, skip=skip, limit=limit)
 
+
+@app.get("/api/v1/summary", response_model=schemas.Summary)
+def get_summary(db: Session = Depends(get_db)):
+    return crud.get_summary(db)
+
 @app.post("/api/v1/review", response_model=schemas.ReviewResult)
 def review_word(review: schemas.ReviewRequest, db: Session = Depends(get_db)):
     return crud.process_review(db, review)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -27,3 +27,9 @@ class ReviewResult(BaseModel):
 class DeckImport(BaseModel):
     name: str
     words: list[WordCreate]
+
+
+class Summary(BaseModel):
+    total_words: int
+    lessons_available: int
+    reviews_due: int

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.14.2"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,23 +1,37 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
+import {
+  BrowserRouter as Router,
+  Routes,
+  Route,
+  Link
+} from 'react-router-dom'
+
+import Dashboard from './components/Dashboard'
+import Lessons from './components/Lessons'
+import Reviews from './components/Reviews'
+import Progress from './components/Progress'
 
 function App() {
-  const [words, setWords] = useState([])
-
-  useEffect(() => {
-    fetch('/api/v1/words')
-      .then(res => res.json())
-      .then(setWords)
-  }, [])
-
   return (
-    <div>
-      <h1>Japanese SRS</h1>
-      <ul>
-        {words.map(w => (
-          <li key={w.id}>{w.japanese} - {w.english}</li>
-        ))}
-      </ul>
-    </div>
+    <Router>
+      <nav>
+        <h1>Japanese SRS</h1>
+        <ul>
+          <li><Link to="/">Dashboard</Link></li>
+          <li><Link to="/lessons">Lessons</Link></li>
+          <li><Link to="/reviews">Reviews</Link></li>
+          <li><Link to="/progress">Progress</Link></li>
+        </ul>
+      </nav>
+      <div className="container">
+        <Routes>
+          <Route path="/" element={<Dashboard />} />
+          <Route path="/lessons" element={<Lessons />} />
+          <Route path="/reviews" element={<Reviews />} />
+          <Route path="/progress" element={<Progress />} />
+        </Routes>
+      </div>
+    </Router>
   )
 }
 

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+
+function Dashboard() {
+  const [summary, setSummary] = useState({
+    total_words: 0,
+    lessons_available: 0,
+    reviews_due: 0
+  })
+
+  useEffect(() => {
+    fetch('/api/v1/summary')
+      .then(res => res.json())
+      .then(setSummary)
+      .catch(console.error)
+  }, [])
+
+  return (
+    <div>
+      <h2>Dashboard</h2>
+      <div className="grid">
+        <div className="card">
+          <h3>Lessons</h3>
+          <p>{summary.lessons_available}</p>
+          <Link to="/lessons" className="button">Start</Link>
+        </div>
+        <div className="card">
+          <h3>Reviews</h3>
+          <p>{summary.reviews_due}</p>
+          <Link to="/reviews" className="button">Start</Link>
+        </div>
+      </div>
+      <p>Total Words: {summary.total_words}</p>
+    </div>
+  )
+}
+
+export default Dashboard

--- a/frontend/src/components/Lessons.jsx
+++ b/frontend/src/components/Lessons.jsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from 'react'
+
+function Lessons() {
+  const [words, setWords] = useState([])
+
+  useEffect(() => {
+    fetch('/api/v1/words')
+      .then(res => res.json())
+      .then(setWords)
+      .catch(console.error)
+  }, [])
+
+  return (
+    <div>
+      <h2>Lessons</h2>
+      <div className="grid">
+        {words.map(w => (
+          <div key={w.id} className="card">
+            {w.japanese} - {w.english}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default Lessons

--- a/frontend/src/components/Progress.jsx
+++ b/frontend/src/components/Progress.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+function Progress() {
+  return (
+    <div>
+      <h2>Progress</h2>
+      <p>More statistics coming soon.</p>
+    </div>
+  )
+}
+
+export default Progress

--- a/frontend/src/components/ReviewCard.jsx
+++ b/frontend/src/components/ReviewCard.jsx
@@ -11,11 +11,15 @@ function ReviewCard({word, onReview}) {
   }
 
   return (
-    <div>
+    <div className="card">
       <p>{word.japanese}</p>
       <form onSubmit={handleSubmit}>
-        <input value={answer} onChange={e => setAnswer(e.target.value)} />
-        <button type="submit">Submit</button>
+        <input
+          type="text"
+          value={answer}
+          onChange={e => setAnswer(e.target.value)}
+        />
+        <button type="submit" className="button">Submit</button>
       </form>
     </div>
   )

--- a/frontend/src/components/Reviews.jsx
+++ b/frontend/src/components/Reviews.jsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react'
+import ReviewCard from './ReviewCard'
+
+function Reviews() {
+  const [words, setWords] = useState([])
+  const [current, setCurrent] = useState(0)
+
+  useEffect(() => {
+    fetch('/api/v1/words')
+      .then(res => res.json())
+      .then(setWords)
+      .catch(console.error)
+  }, [])
+
+  const handleReview = (id, correct) => {
+    fetch('/api/v1/review', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ word_id: id, correct })
+    }).then(() => {
+      setCurrent(c => c + 1)
+    })
+  }
+
+  if (!words.length) return <div>Loading...</div>
+  if (current >= words.length) return <div>No more reviews</div>
+
+  return (
+    <div>
+      <h2>Reviews</h2>
+      <ReviewCard word={words[current]} onReview={handleReview} />
+    </div>
+  )
+}
+
+export default Reviews

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,61 @@
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  background: #f5f5f5;
+}
+
+nav {
+  background: #8649ad;
+  color: white;
+  padding: 1rem;
+}
+
+nav h1 {
+  margin: 0 0 0.5rem 0;
+}
+
+nav ul {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  gap: 1rem;
+}
+
+nav a {
+  color: white;
+  text-decoration: none;
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.grid {
+  display: flex;
+  gap: 1rem;
+}
+
+.card {
+  background: white;
+  padding: 1rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  flex: 1;
+}
+
+.button {
+  display: inline-block;
+  margin-top: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: #8649ad;
+  color: white;
+  text-decoration: none;
+  border-radius: 4px;
+}
+
+input[type="text"] {
+  padding: 0.25rem;
+  font-size: 1rem;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
+import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- create `/api/v1/summary` endpoint for lessons/reviews counts
- add global CSS with purple navigation and cards
- show Lesson and Review counts on Dashboard with start links
- list lesson items in cards
- style Review cards

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: react-router-dom not resolved)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6861ecb9ba1c83338c147c783f31cb5b