### PR TITLE
Add basic lessons and reviews endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cd backend
 python -m venv venv
 venv\Scripts\activate
 pip install -r requirements.txt
-uvicorn app.main:app --reload
+uvicorn main:app --reload
 ```
 
 4. In another terminal, set up the frontend:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -34,6 +34,16 @@ def dictionary(db: Session = Depends(get_db)):
     return crud.get_words(db)
 
 
+@app.get("/api/v1/lessons", response_model=list[schemas.Word])
+def get_lessons(limit: int = 15, db: Session = Depends(get_db)):
+    return crud.get_lessons(db, limit=limit)
+
+
+@app.get("/api/v1/reviews", response_model=list[schemas.Word])
+def get_reviews(db: Session = Depends(get_db)):
+    return crud.get_reviews(db)
+
+
 @app.get("/api/v1/summary", response_model=schemas.Summary)
 def get_summary(db: Session = Depends(get_db)):
     return crud.get_summary(db)

--- a/frontend/src/components/Lessons.jsx
+++ b/frontend/src/components/Lessons.jsx
@@ -5,7 +5,7 @@ function Lessons() {
   const [file, setFile] = useState(null)
 
   useEffect(() => {
-    fetch('/api/v1/words')
+    fetch('/api/v1/lessons')
       .then(res => res.json())
       .then(setWords)
       .catch(console.error)

--- a/frontend/src/components/Reviews.jsx
+++ b/frontend/src/components/Reviews.jsx
@@ -6,7 +6,7 @@ function Reviews() {
   const [current, setCurrent] = useState(0)
 
   useEffect(() => {
-    fetch('/api/v1/words')
+    fetch('/api/v1/reviews')
       .then(res => res.json())
       .then(setWords)
       .catch(console.error)


### PR DESCRIPTION
## Summary
- update backend to track lessons and reviews
- expose `/api/v1/lessons` and `/api/v1/reviews`
- adjust CSV import to tag deck/jlpt info
- update frontend Lessons and Reviews pages to use new endpoints
- fix README backend run command

## Testing
- `npm run build`
- `python -m py_compile backend/app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6861fa9c47f08333913ecb247a370271